### PR TITLE
fixed TimeInForce GoodTillTime for PlaceLimitOrderAsync()

### DIFF
--- a/GDAXClient/Services/Orders/OrdersService.cs
+++ b/GDAXClient/Services/Orders/OrdersService.cs
@@ -92,6 +92,7 @@ namespace GDAXClient.Services.Orders
                 type = OrderType.Limit.ToString().ToLower(),
                 price = price,
                 size = size,
+                time_in_force = TimeInForce.Gtt.ToString().ToUpper(),
                 cancel_after = cancelAfter.ToString().ToLower(),
                 post_only = postOnly
             });

--- a/GDAXClient/Services/Orders/TimeInForce.cs
+++ b/GDAXClient/Services/Orders/TimeInForce.cs
@@ -3,6 +3,7 @@
     public enum TimeInForce
     {
         Gtc,
+        Gtt,
         Ioc,
         Fok
     }


### PR DESCRIPTION
I think this is what you were talking about for line 96

the compiler says that optional parameters must appear after all required parameters so I removed `TimeInForce timeInForce` from the method and subsequently, `time_in_force = TimeInForce.Gtt.ToString().ToUpper()` became line 95 rather than line 96