### PR TITLE
[Feature] Centralize error handling

### DIFF
--- a/GDAXSharp.Specs/JsonFixtures/Services/Orders/CancelOrderResponseFixture.cs
+++ b/GDAXSharp.Specs/JsonFixtures/Services/Orders/CancelOrderResponseFixture.cs
@@ -13,6 +13,16 @@
             return json;
         }
 
+        public static string CreateOne()
+        {
+            var json = @"
+[
+    ""144c6f8e-713f-4682-8435-5280fbe8b2b4""
+]";
+
+            return json;
+        }
+
         public static string CreateEmpty()
         {
             var json = @"

--- a/GDAXSharp.Specs/Services/Orders/OrdersServiceSpecs.cs
+++ b/GDAXSharp.Specs/Services/Orders/OrdersServiceSpecs.cs
@@ -145,7 +145,7 @@ namespace GDAXSharp.Specs.Services.Orders
                     .Return(Task.FromResult(new HttpResponseMessage(HttpStatusCode.Accepted)));
 
                 The<IHttpClient>().WhenToldTo(p => p.ReadAsStringAsync(Param.IsAny<HttpResponseMessage>()))
-                    .Return(Task.FromResult(CancelOrderResponseFixture.Create()));
+                    .Return(Task.FromResult(CancelOrderResponseFixture.CreateOne()));
             };
 
             Because of = () =>
@@ -192,7 +192,7 @@ namespace GDAXSharp.Specs.Services.Orders
             It should_have_correct_number_of_orders = () =>
                 order_many_response_result.First().Count.ShouldEqual(2);
 
-            private It should_have_correct_orders = () =>
+            It should_have_correct_orders = () =>
             {
                 order_many_response_result.First().First().Id.ShouldEqual(new Guid("d0c5340b-6d6c-49d9-b567-48c4bfca13d2"));
                 order_many_response_result.First().First().Price.ShouldEqual(0.10000000M);

--- a/GDAXSharp.Specs/Services/Orders/OrdersServiceSpecs.cs
+++ b/GDAXSharp.Specs/Services/Orders/OrdersServiceSpecs.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
+using GDAXSharp.Exceptions;
 using GDAXSharp.Network.HttpClient;
 using GDAXSharp.Services.Orders;
 using GDAXSharp.Services.Orders.Models.Responses;
@@ -171,9 +172,10 @@ namespace GDAXSharp.Specs.Services.Orders
             Because of = () =>
                 exception = Catch.Exception(() => Subject.CancelOrderByIdAsync("144c6f8e-713f-4682-8435-5280fbe8b2b4").Result);
 
-            It should_have_correct_error_response_message = () =>
+            private It should_have_correct_error_response_message = () =>
             {
-                exception.InnerException.ShouldBeOfExactType<HttpRequestException>();
+                exception.InnerException.ShouldBeOfExactType<GDAXSharpHttpException>();
+                ((GDAXSharpHttpException) exception.InnerException)?.StatusCode.ShouldEqual(HttpStatusCode.NotFound);
                 exception.InnerException.ShouldContainErrorMessage("order not found");
             };
         }

--- a/GDAXSharp.Specs/Services/Orders/OrdersServiceSpecs.cs
+++ b/GDAXSharp.Specs/Services/Orders/OrdersServiceSpecs.cs
@@ -172,7 +172,7 @@ namespace GDAXSharp.Specs.Services.Orders
             Because of = () =>
                 exception = Catch.Exception(() => Subject.CancelOrderByIdAsync("144c6f8e-713f-4682-8435-5280fbe8b2b4").Result);
 
-            private It should_have_correct_error_response_message = () =>
+            It should_have_correct_error_response_message = () =>
             {
                 exception.InnerException.ShouldBeOfExactType<GDAXSharpHttpException>();
                 ((GDAXSharpHttpException) exception.InnerException)?.StatusCode.ShouldEqual(HttpStatusCode.NotFound);

--- a/GDAXSharp/Exceptions/GDAXErrorMessage.cs
+++ b/GDAXSharp/Exceptions/GDAXErrorMessage.cs
@@ -1,0 +1,7 @@
+﻿namespace GDAXSharp.Exceptions
+{
+    public class GDAXErrorMessage
+    {
+        public string Message { get; set; }
+    }
+}

--- a/GDAXSharp/Exceptions/GDAXSharpHttpException.cs
+++ b/GDAXSharp/Exceptions/GDAXSharpHttpException.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Net;
+using System.Net.Http;
+using GDAXSharp.Services;
+
+namespace GDAXSharp.Exceptions
+{
+    public class GDAXSharpHttpException : HttpRequestException
+    {
+        public HttpStatusCode StatusCode { get; set; }
+
+        public IEndPoint EndPoint { get; set; }
+
+        public HttpRequestMessage RequestMessage { get; set; }
+
+        public HttpResponseMessage ResponseMessage { get; set; }
+
+        public GDAXSharpHttpException()
+        {
+        }
+
+        public GDAXSharpHttpException(string message) : base(message)
+        {
+        }
+
+        public GDAXSharpHttpException(string message, Exception inner) : base(message, inner)
+        {
+        }
+    }
+}

--- a/GDAXSharp/GDAXSharp.csproj
+++ b/GDAXSharp/GDAXSharp.csproj
@@ -52,6 +52,8 @@
     <Reference Include="System.Xml.Serialization" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Exceptions\GDAXErrorMessage.cs" />
+    <Compile Include="Exceptions\GDAXSharpHttpException.cs" />
     <Compile Include="Network\Authentication\Authenticator.cs" />
     <Compile Include="GDAXClient.cs" />
     <Compile Include="Network\HttpClient\HttpClient.cs" />
@@ -60,6 +62,7 @@
     <Compile Include="Services\Accounts\Types\AccountHoldType.cs" />
     <Compile Include="Services\CoinbaseAccounts\Types\CoinbaseAccountType.cs" />
     <Compile Include="Services\Fills\Types\FillLiquidity.cs" />
+    <Compile Include="Services\IEndPoint.cs" />
     <Compile Include="Services\Orders\Types\GoodTillTime.cs" />
     <Compile Include="Services\Orders\Types\OrderStatus.cs" />
     <Compile Include="Services\Orders\Types\TimeInForce.cs" />

--- a/GDAXSharp/Services/AbstractService.cs
+++ b/GDAXSharp/Services/AbstractService.cs
@@ -3,7 +3,6 @@ using System.Linq;
 using System.Net.Http;
 using System.Threading.Tasks;
 using GDAXSharp.Exceptions;
-using GDAXSharp.Network.Authentication;
 using GDAXSharp.Network.HttpClient;
 using GDAXSharp.Network.HttpRequest;
 using Newtonsoft.Json;
@@ -35,7 +34,7 @@ namespace GDAXSharp.Services
             this.httpClient = httpClient;
         }
 
-        protected async Task<HttpResponseMessage> SendHttpRequestMessageAsync(
+        private async Task<HttpResponseMessage> SendHttpRequestMessageAsync(
             HttpMethod httpMethod,
             string uri,
             string content = null)

--- a/GDAXSharp/Services/Accounts/AccountsService.cs
+++ b/GDAXSharp/Services/Accounts/AccountsService.cs
@@ -1,7 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Net.Http;
 using System.Threading.Tasks;
-using GDAXSharp.Network.Authentication;
 using GDAXSharp.Network.HttpClient;
 using GDAXSharp.Network.HttpRequest;
 using GDAXSharp.Services.Accounts.Models;

--- a/GDAXSharp/Services/CoinbaseAccounts/CoinbaseAccountsService.cs
+++ b/GDAXSharp/Services/CoinbaseAccounts/CoinbaseAccountsService.cs
@@ -1,7 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Net.Http;
 using System.Threading.Tasks;
-using GDAXSharp.Network.Authentication;
 using GDAXSharp.Network.HttpClient;
 using GDAXSharp.Network.HttpRequest;
 using GDAXSharp.Services.CoinbaseAccounts.Models;

--- a/GDAXSharp/Services/Currencies/CurrenciesService.cs
+++ b/GDAXSharp/Services/Currencies/CurrenciesService.cs
@@ -1,7 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Net.Http;
 using System.Threading.Tasks;
-using GDAXSharp.Network.Authentication;
 using GDAXSharp.Network.HttpClient;
 using GDAXSharp.Network.HttpRequest;
 

--- a/GDAXSharp/Services/Deposits/DepositsService.cs
+++ b/GDAXSharp/Services/Deposits/DepositsService.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Net.Http;
 using System.Threading.Tasks;
-using GDAXSharp.Network.Authentication;
 using GDAXSharp.Network.HttpClient;
 using GDAXSharp.Network.HttpRequest;
 using GDAXSharp.Services.Deposits.Models;

--- a/GDAXSharp/Services/Fills/FillsService.cs
+++ b/GDAXSharp/Services/Fills/FillsService.cs
@@ -1,7 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Net.Http;
 using System.Threading.Tasks;
-using GDAXSharp.Network.Authentication;
 using GDAXSharp.Network.HttpClient;
 using GDAXSharp.Network.HttpRequest;
 using GDAXSharp.Services.Fills.Models.Responses;

--- a/GDAXSharp/Services/Fundings/FundingsService.cs
+++ b/GDAXSharp/Services/Fundings/FundingsService.cs
@@ -1,7 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Net.Http;
 using System.Threading.Tasks;
-using GDAXSharp.Network.Authentication;
 using GDAXSharp.Network.HttpClient;
 using GDAXSharp.Network.HttpRequest;
 using GDAXSharp.Services.Fundings.Models;

--- a/GDAXSharp/Services/IEndPoint.cs
+++ b/GDAXSharp/Services/IEndPoint.cs
@@ -13,10 +13,6 @@ namespace GDAXSharp.Services
 
     public class EndPoint : IEndPoint
     {
-        public HttpMethod HttpMethod { get; }
-        public string Uri { get; }
-        public string Content { get; }
-
         public EndPoint(HttpMethod httpMethod,
             string uri, string content)
         {
@@ -24,5 +20,11 @@ namespace GDAXSharp.Services
             Uri = uri;
             Content = content;
         }
+
+        public HttpMethod HttpMethod { get; }
+
+        public string Uri { get; }
+
+        public string Content { get; }
     }
 }

--- a/GDAXSharp/Services/IEndPoint.cs
+++ b/GDAXSharp/Services/IEndPoint.cs
@@ -1,0 +1,28 @@
+﻿using System.Net.Http;
+
+namespace GDAXSharp.Services
+{
+    public interface IEndPoint
+    {
+        HttpMethod HttpMethod {get;}
+
+        string Uri {get;}
+
+        string Content { get; }
+    }
+
+    public class EndPoint : IEndPoint
+    {
+        public HttpMethod HttpMethod { get; }
+        public string Uri { get; }
+        public string Content { get; }
+
+        public EndPoint(HttpMethod httpMethod,
+            string uri, string content)
+        {
+            HttpMethod = httpMethod;
+            Uri = uri;
+            Content = content;
+        }
+    }
+}

--- a/GDAXSharp/Services/Orders/OrdersService.cs
+++ b/GDAXSharp/Services/Orders/OrdersService.cs
@@ -118,25 +118,10 @@ namespace GDAXSharp.Services.Orders
 
         public async Task<CancelOrderResponse> CancelOrderByIdAsync(string id)
         {
-            try
+            return new CancelOrderResponse
             {
-                return new CancelOrderResponse
-                {
-                    OrderIds = await SendServiceCall<IEnumerable<Guid>>(HttpMethod.Delete, $"/orders/{id}")
-                };
-            }
-            catch (GDAXSharpHttpException error)
-            {
-                if (error.StatusCode == HttpStatusCode.NotFound)
-                {
-                    return new CancelOrderResponse
-                    {
-                        OrderIds = Enumerable.Empty<Guid>()
-                    };
-                }
-
-                throw;
-            }
+                OrderIds = await SendServiceCall<IEnumerable<Guid>>(HttpMethod.Delete, $"/orders/{id}")
+            };
         }
 
         public async Task<IList<IList<OrderResponse>>> GetAllOrdersAsync(

--- a/GDAXSharp/Services/Payments/PaymentsService.cs
+++ b/GDAXSharp/Services/Payments/PaymentsService.cs
@@ -1,7 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Net.Http;
 using System.Threading.Tasks;
-using GDAXSharp.Network.Authentication;
 using GDAXSharp.Network.HttpClient;
 using GDAXSharp.Network.HttpRequest;
 using GDAXSharp.Services.Payments.Models;

--- a/GDAXSharp/Services/Products/ProductsService.cs
+++ b/GDAXSharp/Services/Products/ProductsService.cs
@@ -4,7 +4,6 @@ using System.Globalization;
 using System.Linq;
 using System.Net.Http;
 using System.Threading.Tasks;
-using GDAXSharp.Network.Authentication;
 using GDAXSharp.Network.HttpClient;
 using GDAXSharp.Network.HttpRequest;
 using GDAXSharp.Services.Products.Models;

--- a/GDAXSharp/Services/Reports/ReportsService.cs
+++ b/GDAXSharp/Services/Reports/ReportsService.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Net.Http;
 using System.Threading.Tasks;
-using GDAXSharp.Network.Authentication;
 using GDAXSharp.Network.HttpClient;
 using GDAXSharp.Network.HttpRequest;
 using GDAXSharp.Services.Reports.Models;

--- a/GDAXSharp/Services/UserAccount/UserAccountService.cs
+++ b/GDAXSharp/Services/UserAccount/UserAccountService.cs
@@ -1,6 +1,5 @@
 ﻿using System.Collections.Generic;
 using System.Net.Http;
-using GDAXSharp.Network.Authentication;
 using GDAXSharp.Network.HttpClient;
 using GDAXSharp.Network.HttpRequest;
 using GDAXSharp.Services.UserAccount.Models;

--- a/GDAXSharp/Services/Withdrawals/WithdrawalsService.cs
+++ b/GDAXSharp/Services/Withdrawals/WithdrawalsService.cs
@@ -1,6 +1,5 @@
 ﻿using System.Net.Http;
 using System.Threading.Tasks;
-using GDAXSharp.Network.Authentication;
 using GDAXSharp.Network.HttpClient;
 using GDAXSharp.Network.HttpRequest;
 using GDAXSharp.Services.Withdrawals.Models;


### PR DESCRIPTION
Invalid calls into paged results are currently not error handled correctly.

// make call with an invalid order status, to force a Bad Request 
var blowUp = await _client.OrdersService.GetAllOrdersAsync((OrderStatus)999));

This change centralizes the error handling an builds an exception with more information on it.

Where in the namespace would you want the IEndPoint? 

It would be useful for a later change to have SendServiceCall and SendHttpRequestMessagePagedAsync take in the IEndPoint as there parameter... and also have httpRequestMessageService.CreateHttpRequestMessage take in IEndPoint as it's parameter - this would allow the for the management of the request pipeline / prioritizing / rate limiting etc. based on the endpoint being called.

