### PR TITLE
[Fix] Allow candle to be null.

### DIFF
--- a/GDAXSharp/Services/Products/Models/Candle.cs
+++ b/GDAXSharp/Services/Products/Models/Candle.cs
@@ -11,16 +11,16 @@ namespace GDAXSharp.Services.Products.Models
         public DateTime Time { get; set; }
 
         [JsonProperty(Order = 2)]
-        public decimal Low { get; set; }
+        public decimal? Low { get; set; }
 
         [JsonProperty(Order = 3)]
-        public decimal High { get; set; }
+        public decimal? High { get; set; }
 
         [JsonProperty(Order = 4)]
-        public decimal Open { get; set; }
+        public decimal? Open { get; set; }
 
         [JsonProperty(Order = 5)]
-        public decimal Close { get; set; }
+        public decimal? Close { get; set; }
 
         [JsonProperty(Order = 6)]
         public decimal Volume { get; set; }

--- a/GDAXSharp/Shared/Utilities/Converters/CandleConverter.cs
+++ b/GDAXSharp/Shared/Utilities/Converters/CandleConverter.cs
@@ -21,10 +21,10 @@ namespace GDAXSharp.Shared.Utilities.Converters
             return new Candle
             {
                 Time = UnixEpoch.AddSeconds((long)jarray.ElementAt(0)),
-                Low = (decimal)jarray.ElementAt(1),
-                High = (decimal)jarray.ElementAt(2),
-                Open = (decimal)jarray.ElementAt(3),
-                Close = (decimal)jarray.ElementAt(4),
+                Low = (decimal?)jarray.ElementAt(1),
+                High = (decimal?)jarray.ElementAt(2),
+                Open = (decimal?)jarray.ElementAt(3),
+                Close = (decimal?)jarray.ElementAt(4),
                 Volume = (decimal)jarray.ElementAt(5)
             };
         }


### PR DESCRIPTION
Sometimes the response of the method `GetHistoricRatesAsync()` can contain candles with `null` values.