### PR TITLE
[Feature] Add public socket event handlers

### DIFF
--- a/GDAXSharp.Specs/WebSocket/WebSocketSpecs.cs
+++ b/GDAXSharp.Specs/WebSocket/WebSocketSpecs.cs
@@ -92,28 +92,6 @@ namespace GDAXSharp.Specs.WebSocket
 
             class when_closed_is_called
             {
-                class with_websocket_state_open
-                {
-                    Establish context = () =>
-                        The<IWebSocketFeed>().WhenToldTo(p => p.State).Return(WebSocketState.Open);
-
-                    Because of = () =>
-                    {
-                        Subject.Start(product_type_inputs, channel_type_inputs);
-
-                        websocket_feed.Raise(e => e.Closed += null, EventArgs.Empty);
-                    };
-
-                    It should_not_have_called_dispose = () =>
-                        The<IWebSocketFeed>().
-                            WasNotToldTo(p => p.Dispose());
-                }
-
-                class with_websocket_state_in_non_open_state
-                {
-                    Establish context = () =>
-                        The<IWebSocketFeed>().WhenToldTo(p => p.State).Return(WebSocketState.Closed);
-
                     Because of = () =>
                     {
                         Subject.Start(product_type_inputs, channel_type_inputs);
@@ -124,7 +102,6 @@ namespace GDAXSharp.Specs.WebSocket
                     It should_have_called_dispose = () =>
                         The<IWebSocketFeed>().
                             WasToldTo(p => p.Dispose());
-                }
             }
 
             class when_message_received_is_called

--- a/GDAXSharp/WebSocket/WebSocket.cs
+++ b/GDAXSharp/WebSocket/WebSocket.cs
@@ -83,6 +83,15 @@ namespace GDAXSharp.WebSocket
             }
 
             stopWebSocket = true;
+
+            var timeStamp = Clock.GetTime().ToTimeStamp();
+            var json = JsonConfig.SerializeObject(new TickerChannel
+            {
+                Type = ActionType.Unsubscribe
+            });
+
+            webSocketFeed.Send(json);
+            webSocketFeed.Close();
         }
 
         public void WebSocket_Opened(object sender, EventArgs e)
@@ -116,7 +125,6 @@ namespace GDAXSharp.WebSocket
         {
             if (stopWebSocket)
             {
-                webSocketFeed.Close();
                 return;
             }
 

--- a/GDAXSharp/WebSocket/WebSocket.cs
+++ b/GDAXSharp/WebSocket/WebSocket.cs
@@ -83,8 +83,7 @@ namespace GDAXSharp.WebSocket
             }
 
             stopWebSocket = true;
-
-            var timeStamp = Clock.GetTime().ToTimeStamp();
+            
             var json = JsonConfig.SerializeObject(new TickerChannel
             {
                 Type = ActionType.Unsubscribe

--- a/GDAXSharp/WebSocket/WebSocket.cs
+++ b/GDAXSharp/WebSocket/WebSocket.cs
@@ -205,7 +205,7 @@ namespace GDAXSharp.WebSocket
             webSocketFeed.Invoke(OnWebSocketClose, sender, new WebfeedEventArgs<EventArgs>(e));
 
             // un-needed check ...
-            if (webSocketFeed.State != WebSocketState.Closed )
+            if (webSocketFeed.State == WebSocketState.Closed )
                 webSocketFeed.Dispose();
 
             if (!stopWebSocket)

--- a/GDAXSharp/WebSocket/WebSocket.cs
+++ b/GDAXSharp/WebSocket/WebSocket.cs
@@ -185,7 +185,7 @@ namespace GDAXSharp.WebSocket
         {
             if(OnWebSocketError != null)
             { 
-                webSocketFeed.Invoke(OnWebSocketError, sender, new WebfeedEventArgs<EventArgs>(e));
+                webSocketFeed.Invoke(OnWebSocketError, sender, new WebfeedEventArgs<ErrorEventArgs>(e));
             }
             else
             {
@@ -242,7 +242,7 @@ namespace GDAXSharp.WebSocket
         public event EventHandler<WebfeedEventArgs<Match>> OnMatchReceived;
         public event EventHandler<WebfeedEventArgs<LastMatch>> OnLastMatchReceived;
         public event EventHandler<WebfeedEventArgs<Error>> OnErrorReceived;
-        public event EventHandler<WebfeedEventArgs<EventArgs>> OnWebSocketError;
+        public event EventHandler<WebfeedEventArgs<ErrorEventArgs>> OnWebSocketError;
         public event EventHandler<WebfeedEventArgs<EventArgs>> OnWebSocketClose;
         public event EventHandler<WebfeedEventArgs<EventArgs>> OnWebSocketOpenAndSubscribed;
     }

--- a/GDAXSharp/WebSocket/WebSocket.cs
+++ b/GDAXSharp/WebSocket/WebSocket.cs
@@ -183,7 +183,7 @@ namespace GDAXSharp.WebSocket
 
         public void WebSocket_Error(object sender, ErrorEventArgs e)
         {
-            if(OnWebSocketError != null )
+            if(OnWebSocketError != null)
             { 
                 webSocketFeed.Invoke(OnWebSocketError, sender, new WebfeedEventArgs<EventArgs>(e));
             }
@@ -196,23 +196,18 @@ namespace GDAXSharp.WebSocket
                     ErrorEvent = e
                 };
             }
-
-
         }
 
         public void WebSocket_Closed(object sender, EventArgs e)
         {
-            webSocketFeed.Invoke(OnWebSocketClose, sender, new WebfeedEventArgs<EventArgs>(e));
-
-            // un-needed check ...
-            if (webSocketFeed.State == WebSocketState.Closed )
-                webSocketFeed.Dispose();
+            webSocketFeed.Invoke(OnWebSocketClose, sender, new WebfeedEventArgs<EventArgs>(e));    
+            
+            webSocketFeed.Dispose();
 
             if (!stopWebSocket)
             {
                 Start(productTypes, channelTypes);
-            }
-            
+            }           
         }
 
         private List<Channel> GetChannels()
@@ -247,8 +242,6 @@ namespace GDAXSharp.WebSocket
         public event EventHandler<WebfeedEventArgs<Match>> OnMatchReceived;
         public event EventHandler<WebfeedEventArgs<LastMatch>> OnLastMatchReceived;
         public event EventHandler<WebfeedEventArgs<Error>> OnErrorReceived;
-
-
         public event EventHandler<WebfeedEventArgs<EventArgs>> OnWebSocketError;
         public event EventHandler<WebfeedEventArgs<EventArgs>> OnWebSocketClose;
         public event EventHandler<WebfeedEventArgs<EventArgs>> OnWebSocketOpenAndSubscribed;

--- a/GDAXSharp/WebSocket/WebSocket.cs
+++ b/GDAXSharp/WebSocket/WebSocket.cs
@@ -204,7 +204,9 @@ namespace GDAXSharp.WebSocket
         {
             webSocketFeed.Invoke(OnWebSocketClose, sender, new WebfeedEventArgs<EventArgs>(e));
 
-            webSocketFeed.Dispose();
+            // un-needed check ...
+            if (webSocketFeed.State != WebSocketState.Closed )
+                webSocketFeed.Dispose();
 
             if (!stopWebSocket)
             {

--- a/README.md
+++ b/README.md
@@ -201,7 +201,6 @@ var authenticator = new Authenticator("<apiKey>", "<signature>", "<passphrase>")
 var gdaxClient = new GDAXClient(authenticator, myWay);
 ````
 
-
 <h1>Contributors</h1>
 
 Thanks for contributing!

--- a/README.md
+++ b/README.md
@@ -201,6 +201,7 @@ var authenticator = new Authenticator("<apiKey>", "<signature>", "<passphrase>")
 var gdaxClient = new GDAXClient(authenticator, myWay);
 ````
 
+
 <h1>Contributors</h1>
 
 Thanks for contributing!

--- a/README.md
+++ b/README.md
@@ -212,6 +212,7 @@ Thanks for contributing!
 - @chrisw000
 - @confessore
 - @sotam
+- @BradForsythe
 
 <h1>Bugs or questions?</h1>
 


### PR DESCRIPTION
Added public callbacks to notify app when sockets, close, open or have an error.  The error event handler now invokes the callback if one is supplied instead of throwing an exception.  Otherwise if none is supplied the exception is thrown.    On the socket close event handler, the function would always return because the websocketstate will always be 'closed' upon entry to the handler.   The old logic would then always return.   This sometimes happens when gdax forcibly closes a socket. 