### PR TITLE
Create new IWebSocketFeed when reconnecting

### DIFF
--- a/GDAXSharp/GDAXClient.cs
+++ b/GDAXSharp/GDAXClient.cs
@@ -1,4 +1,5 @@
 ﻿using GDAXSharp.Network.Authentication;
+using System;
 using GDAXSharp.Network.HttpClient;
 using GDAXSharp.Network.HttpRequest;
 using GDAXSharp.Services.Accounts;
@@ -36,7 +37,7 @@ namespace GDAXSharp
         {
             var clock = new Clock();
             var httpRequestMessageService = new HttpRequestMessageService(authenticator, clock, sandBox);
-            var webSocketFeed = new WebSocketFeed(sandBox);
+            var createWebSocketFeed = (Func<IWebSocketFeed>)(() => new WebSocketFeed(sandBox));
             var queryBuilder = new QueryBuilder();
 
             AccountsService = new AccountsService(httpClient, httpRequestMessageService);
@@ -51,7 +52,7 @@ namespace GDAXSharp
             FundingsService = new FundingsService(httpClient, httpRequestMessageService, queryBuilder);
             ReportsService = new ReportsService(httpClient, httpRequestMessageService);
             UserAccountService = new UserAccountService(httpClient, httpRequestMessageService);
-            WebSocket = new WebSocket.WebSocket(webSocketFeed, authenticator, clock);
+            WebSocket = new WebSocket.WebSocket(createWebSocketFeed, authenticator, clock);
         }
 
         public AccountsService AccountsService { get; }

--- a/GDAXSharp/WebSocket/WebSocket.cs
+++ b/GDAXSharp/WebSocket/WebSocket.cs
@@ -18,7 +18,7 @@ namespace GDAXSharp.WebSocket
 {
     public class WebSocket
     {
-        private readonly IWebSocketFeed webSocketFeed;
+        private readonly Func<IWebSocketFeed> createWebSocketFeed;
 
         private readonly IAuthenticator authenticator;
 
@@ -30,14 +30,16 @@ namespace GDAXSharp.WebSocket
 
         private List<ChannelType> channelTypes;
 
+        private IWebSocketFeed webSocketFeed;
+
         public WebSocketState State => webSocketFeed.State;
 
         public WebSocket(
-            IWebSocketFeed webSocketFeed,
+            Func<IWebSocketFeed> createWebSocketFeed,
             IAuthenticator authenticator,
             IClock clock)
         {
-            this.webSocketFeed = webSocketFeed;
+            this.createWebSocketFeed = createWebSocketFeed;
             this.authenticator = authenticator;
             this.clock = clock;
         }
@@ -62,6 +64,7 @@ namespace GDAXSharp.WebSocket
             productTypes = providedProductTypes;
             channelTypes = providedChannelTypes;
 
+            webSocketFeed = createWebSocketFeed();
             webSocketFeed.Closed += WebSocket_Closed;
             webSocketFeed.Error += WebSocket_Error;
             webSocketFeed.MessageReceived += WebSocket_MessageReceived;


### PR DESCRIPTION
This change is to fix a `NullReferenceException` which is thrown upon reconnecting.

The reason this exception is thrown is that `WebSocket_Closed` disposes the `WebSocket` (`webSocketFeed`) [here](https://github.com/dougdellolio/gdax-csharp/blob/master/GDAXSharp/WebSocket/WebSocket.cs#L205). `WebSocket.Dispose` is setting it's `TcpClientSession` to `null` [here](https://github.com/kerryjiang/WebSocket4Net/blob/master/WebSocket4Net/WebSocket.cs#L789). As a result, when we call `Start` and try to `Open` the web socket again [here](https://github.com/dougdellolio/gdax-csharp/blob/master/GDAXSharp/WebSocket/WebSocket.cs#L69), we get the exception due to `Client` being `null`.

My change modifies our `WebSocket` class to take a `Func<IWebSocketFeed>` so that each time we call `Start`, we can make a new `IWebSocketFeed`. There is an open issue, kerryjiang/WebSocket4Net#99, about this preventing reuse. Other socket libraries suggest just creating a new client like this PR, which work for me in practice.

It'd be nice if this could be merged, and if a new NuGet package could be published to pick up other changes (like the WebSocketX events that were added).

Thanks!