### PR TITLE
Add support for stop limit orders

### DIFF
--- a/GDAXSharp.Specs/GDAXSharp.Specs.csproj
+++ b/GDAXSharp.Specs/GDAXSharp.Specs.csproj
@@ -118,6 +118,7 @@
     <Compile Include="JsonFixtures\Services\Fundings\FundingsResponseFixture.cs" />
     <Compile Include="JsonFixtures\Network\HttpResponseMessage\HttpResponseMessageFixture.cs" />
     <Compile Include="JsonFixtures\Services\Orders\CancelOrderResponseFixture.cs" />
+    <Compile Include="JsonFixtures\Services\Orders\OrderRequestFixture.cs" />
     <Compile Include="JsonFixtures\Services\Orders\OrderResponseFixture.cs" />
     <Compile Include="JsonFixtures\Services\Payments\PaymentMethodsResponseFixture.cs" />
     <Compile Include="JsonFixtures\Services\Products\ProductsOrderBookResponseFixture.cs" />

--- a/GDAXSharp.Specs/JsonFixtures/Services/Orders/OrderRequestFixture.cs
+++ b/GDAXSharp.Specs/JsonFixtures/Services/Orders/OrderRequestFixture.cs
@@ -1,0 +1,90 @@
+﻿using System.Net.Http;
+
+namespace GDAXSharp.Specs.JsonFixtures.Services.Orders
+{
+    public static class OrderRequestFixture
+    {
+        public static HttpRequestMessage CreateRequest(string content)
+        {
+            return new HttpRequestMessage(HttpMethod.Get, "")
+            {
+                Content = new StringContent(content)
+            };
+        }
+
+        public static string CreateMarketOrderRequest()
+        {
+            var json = @"
+{
+    ""side"":""buy"",
+    ""size"":0.01,
+    ""price"":0.0,
+    ""type"":""market"",
+    ""product_id"":""BTC-USD"",
+    ""time_in_force"":""GTC"",
+    ""cancel_after"":""min"",
+    ""post_only"":false
+}";
+
+            return Format(json);
+        }
+
+        public static string CreateLimitOrderRequest()
+        {
+            var json = @"
+{
+    ""side"":""buy"",
+    ""size"":0.01,
+    ""price"":0.1,
+    ""type"":""limit"",
+    ""product_id"":""BTC-USD"",
+    ""time_in_force"":""GTT"",
+    ""cancel_after"":""min"",
+    ""post_only"":true
+}";
+
+            return Format(json);
+        }
+
+        public static string CreateStopOrderRequest()
+        {
+            var json = @"
+{
+    ""side"":""buy"",
+    ""size"":0.01,
+    ""price"":0.1,
+    ""type"":""stop"",
+    ""product_id"":""BTC-USD"",
+    ""time_in_force"":""GTC"",
+    ""cancel_after"":""min"",
+    ""post_only"":false
+}";
+
+            return Format(json);
+        }
+
+        public static string CreateStopLimitOrderRequest()
+        {
+            var json = @"
+{
+    ""side"":""buy"",
+    ""size"":0.01,
+    ""price"":0.1,
+    ""stop"":""entry"",
+    ""stop_price"":0.1,
+    ""type"":""limit"",
+    ""product_id"":""BTC-USD"",
+    ""time_in_force"":""GTC"",
+    ""cancel_after"":""min"",
+    ""post_only"":false
+}";
+
+            return Format(json);
+        }
+
+        private static string Format(string json)
+        {
+            return json.Replace("\r\n", "").Replace(" ", "");
+        }
+    }
+}

--- a/GDAXSharp.Specs/JsonFixtures/Services/Orders/OrderResponseFixture.cs
+++ b/GDAXSharp.Specs/JsonFixtures/Services/Orders/OrderResponseFixture.cs
@@ -76,7 +76,31 @@ namespace GDAXSharp.Specs.JsonFixtures.Services.Orders
             return json;
         }
 
-        public static string CreateLimitOrderMany(OrderStatus orderStatus = OrderStatus.Pending)
+	    public static string CreateStopLimitOrder()
+	    {
+		    var json = @"
+{
+    ""id"": ""d0c5340b-6d6c-49d9-b567-48c4bfca13d2"",
+    ""price"": ""0.10000000"",
+    ""size"": ""0.01000000"",
+    ""product_id"": ""BTC-USD"",
+    ""side"": ""buy"",
+    ""stp"": ""dc"",
+    ""type"": ""limit"",
+    ""time_in_force"": ""GTC"",
+    ""post_only"": false,
+    ""created_at"": ""2016-12-08T24:00:00Z"",
+    ""fill_fees"": ""0.0000000000000000"",
+    ""filled_size"": ""0.00000000"",
+    ""executed_value"": ""0.0000000000000000"",
+    ""status"": ""pending"",
+    ""settled"": false
+}";
+
+		    return json;
+	    }
+
+	    public static string CreateLimitOrderMany(OrderStatus orderStatus = OrderStatus.Pending)
         {
             var json = $@"
 [

--- a/GDAXSharp.Specs/Services/Orders/OrdersServiceSpecs.cs
+++ b/GDAXSharp.Specs/Services/Orders/OrdersServiceSpecs.cs
@@ -118,6 +118,35 @@ namespace GDAXSharp.Specs.Services.Orders
             };
         }
 
+	    class when_placing_a_stop_limit_order
+	    {
+		    Establish context = () =>
+			    The<IHttpClient>().WhenToldTo(p => p.ReadAsStringAsync(Param.IsAny<HttpResponseMessage>()))
+				    .Return(Task.FromResult(OrderResponseFixture.CreateStopLimitOrder()));
+
+			Because of = () =>
+				order_response_result = Subject.PlaceStopLimitOrderAsync(OrderSide.Buy, ProductType.BtcUsd, .01M, .1M, .1M, false).Result;
+
+		    It should_have_correct_order_information = () =>
+		    {
+			    order_response_result.Id.ShouldEqual(new Guid("d0c5340b-6d6c-49d9-b567-48c4bfca13d2"));
+			    order_response_result.Price.ShouldEqual(0.10000000M);
+			    order_response_result.Size.ShouldEqual(0.01000000M);
+			    order_response_result.ProductId.ShouldEqual(ProductType.BtcUsd);
+			    order_response_result.Side.ShouldEqual(OrderSide.Buy);
+			    order_response_result.Stp.ShouldEqual("dc");
+			    order_response_result.OrderType.ShouldEqual(OrderType.Limit);
+			    order_response_result.TimeInForce.ShouldEqual(TimeInForce.Gtc);
+			    order_response_result.PostOnly.ShouldBeFalse();
+			    order_response_result.CreatedAt.ShouldEqual(new DateTime(2016, 12, 9));
+			    order_response_result.FillFees.ShouldEqual(0.0000000000000000M);
+			    order_response_result.FilledSize.ShouldEqual(0.00000000M);
+			    order_response_result.ExecutedValue.ShouldEqual(0.0000000000000000M);
+			    order_response_result.Status.ShouldEqual(OrderStatus.Pending);
+			    order_response_result.Settled.ShouldBeFalse();
+			};
+	    }
+
         class when_cancelling_all_orders
         {
             Establish context = () =>

--- a/GDAXSharp.Specs/Services/Orders/OrdersServiceSpecs.cs
+++ b/GDAXSharp.Specs/Services/Orders/OrdersServiceSpecs.cs
@@ -6,6 +6,7 @@ using System.Net.Http;
 using System.Threading.Tasks;
 using GDAXSharp.Exceptions;
 using GDAXSharp.Network.HttpClient;
+using GDAXSharp.Network.HttpRequest;
 using GDAXSharp.Services.Orders;
 using GDAXSharp.Services.Orders.Models.Responses;
 using GDAXSharp.Services.Orders.Types;
@@ -28,8 +29,13 @@ namespace GDAXSharp.Specs.Services.Orders
         static Exception exception;
 
         Establish context = () =>
+        {
             The<IHttpClient>().WhenToldTo(p => p.SendAsync(Param.IsAny<HttpRequestMessage>()))
                 .Return(Task.FromResult(new HttpResponseMessage()));
+
+            The<IHttpRequestMessageService>().WhenToldTo(p => p.CreateHttpRequestMessage(Param.IsAny<HttpMethod>(), Param.IsAny<string>(), Param.IsAny<string>()))
+                .Return<HttpMethod, string, string>((httpMethod, uri, content) => OrderRequestFixture.CreateRequest(content));
+        };
 
         class when_placing_a_market_order
         {
@@ -39,6 +45,9 @@ namespace GDAXSharp.Specs.Services.Orders
 
             Because of = () =>
                 order_response_result = Subject.PlaceMarketOrderAsync(OrderSide.Buy, ProductType.BtcUsd, .01M).Result;
+
+            It should_send_the_correct_request = () => 
+                VerifyRequestContent(The<IHttpClient>(), OrderRequestFixture.CreateMarketOrderRequest());
 
             It should_have_correct_order_information = () =>
             {
@@ -69,6 +78,9 @@ namespace GDAXSharp.Specs.Services.Orders
             Because of = () =>
                 order_response_result = Subject.PlaceLimitOrderAsync(OrderSide.Buy, ProductType.BtcUsd, .01M, 0.1M, GoodTillTime.Min).Result;
 
+            It should_send_the_correct_request = () =>
+                VerifyRequestContent(The<IHttpClient>(), OrderRequestFixture.CreateLimitOrderRequest());
+
             It should_have_correct_order_information = () =>
             {
                 order_response_result.Id.ShouldEqual(new Guid("d0c5340b-6d6c-49d9-b567-48c4bfca13d2"));
@@ -98,6 +110,9 @@ namespace GDAXSharp.Specs.Services.Orders
             Because of = () =>
                 order_response_result = Subject.PlaceStopOrderAsync(OrderSide.Buy, ProductType.BtcUsd, .01M, .1M).Result;
 
+            It should_send_the_correct_request = () =>
+                VerifyRequestContent(The<IHttpClient>(), OrderRequestFixture.CreateStopOrderRequest());
+
             It should_have_correct_order_information = () =>
             {
                 order_response_result.Id.ShouldEqual(new Guid("d0c5340b-6d6c-49d9-b567-48c4bfca13d2"));
@@ -118,34 +133,37 @@ namespace GDAXSharp.Specs.Services.Orders
             };
         }
 
-	    class when_placing_a_stop_limit_order
-	    {
-		    Establish context = () =>
-			    The<IHttpClient>().WhenToldTo(p => p.ReadAsStringAsync(Param.IsAny<HttpResponseMessage>()))
-				    .Return(Task.FromResult(OrderResponseFixture.CreateStopLimitOrder()));
+        class when_placing_a_stop_limit_order
+        {
+            Establish context = () =>
+                The<IHttpClient>().WhenToldTo(p => p.ReadAsStringAsync(Param.IsAny<HttpResponseMessage>()))
+                    .Return(Task.FromResult(OrderResponseFixture.CreateStopLimitOrder()));
 
-			Because of = () =>
-				order_response_result = Subject.PlaceStopLimitOrderAsync(OrderSide.Buy, ProductType.BtcUsd, .01M, .1M, .1M, false).Result;
+            Because of = () =>
+                order_response_result = Subject.PlaceStopLimitOrderAsync(OrderSide.Buy, ProductType.BtcUsd, .01M, .1M, .1M, false).Result;
 
-		    It should_have_correct_order_information = () =>
-		    {
-			    order_response_result.Id.ShouldEqual(new Guid("d0c5340b-6d6c-49d9-b567-48c4bfca13d2"));
-			    order_response_result.Price.ShouldEqual(0.10000000M);
-			    order_response_result.Size.ShouldEqual(0.01000000M);
-			    order_response_result.ProductId.ShouldEqual(ProductType.BtcUsd);
-			    order_response_result.Side.ShouldEqual(OrderSide.Buy);
-			    order_response_result.Stp.ShouldEqual("dc");
-			    order_response_result.OrderType.ShouldEqual(OrderType.Limit);
-			    order_response_result.TimeInForce.ShouldEqual(TimeInForce.Gtc);
-			    order_response_result.PostOnly.ShouldBeFalse();
-			    order_response_result.CreatedAt.ShouldEqual(new DateTime(2016, 12, 9));
-			    order_response_result.FillFees.ShouldEqual(0.0000000000000000M);
-			    order_response_result.FilledSize.ShouldEqual(0.00000000M);
-			    order_response_result.ExecutedValue.ShouldEqual(0.0000000000000000M);
-			    order_response_result.Status.ShouldEqual(OrderStatus.Pending);
-			    order_response_result.Settled.ShouldBeFalse();
-			};
-	    }
+            It should_send_the_correct_request = () =>
+                VerifyRequestContent(The<IHttpClient>(), OrderRequestFixture.CreateStopLimitOrderRequest());
+
+            It should_have_correct_order_information = () =>
+            {
+                order_response_result.Id.ShouldEqual(new Guid("d0c5340b-6d6c-49d9-b567-48c4bfca13d2"));
+                order_response_result.Price.ShouldEqual(0.10000000M);
+                order_response_result.Size.ShouldEqual(0.01000000M);
+                order_response_result.ProductId.ShouldEqual(ProductType.BtcUsd);
+                order_response_result.Side.ShouldEqual(OrderSide.Buy);
+                order_response_result.Stp.ShouldEqual("dc");
+                order_response_result.OrderType.ShouldEqual(OrderType.Limit);
+                order_response_result.TimeInForce.ShouldEqual(TimeInForce.Gtc);
+                order_response_result.PostOnly.ShouldBeFalse();
+                order_response_result.CreatedAt.ShouldEqual(new DateTime(2016, 12, 9));
+                order_response_result.FillFees.ShouldEqual(0.0000000000000000M);
+                order_response_result.FilledSize.ShouldEqual(0.00000000M);
+                order_response_result.ExecutedValue.ShouldEqual(0.0000000000000000M);
+                order_response_result.Status.ShouldEqual(OrderStatus.Pending);
+                order_response_result.Settled.ShouldBeFalse();
+            };
+        }
 
         class when_cancelling_all_orders
         {
@@ -332,6 +350,12 @@ namespace GDAXSharp.Specs.Services.Orders
                 order_response_result.Status.ShouldEqual(OrderStatus.Pending);
                 order_response_result.Settled.ShouldBeFalse();
             };
+        }
+
+        private static void VerifyRequestContent(IHttpClient httpClient, string content)
+        {
+            httpClient.WasToldTo(p => p.SendAsync(Param<HttpRequestMessage>.Matches(r =>
+                r.Content.ReadAsStringAsync().Result == content)));
         }
     }
 }

--- a/GDAXSharp/GDAXSharp.csproj
+++ b/GDAXSharp/GDAXSharp.csproj
@@ -89,6 +89,7 @@
     <Compile Include="GDAXClient.cs" />
     <Compile Include="Network\HttpClient\HttpClient.cs" />
     <Compile Include="Network\HttpClient\IHttpClient.cs" />
+    <Compile Include="Services\Orders\Types\StopType.cs" />
     <Compile Include="Shared\ApiUris.cs" />
     <Compile Include="Shared\Utilities\JsonConfig.cs" />
     <Compile Include="WebSocket\Models\Response\Done.cs" />

--- a/GDAXSharp/GDAXSharp.csproj
+++ b/GDAXSharp/GDAXSharp.csproj
@@ -89,6 +89,7 @@
     <Compile Include="GDAXClient.cs" />
     <Compile Include="Network\HttpClient\HttpClient.cs" />
     <Compile Include="Network\HttpClient\IHttpClient.cs" />
+    <Compile Include="Services\Orders\Models\StopLimitOrder.cs" />
     <Compile Include="Services\Orders\Types\StopType.cs" />
     <Compile Include="Shared\ApiUris.cs" />
     <Compile Include="Shared\Utilities\JsonConfig.cs" />

--- a/GDAXSharp/Services/Orders/Models/Order.cs
+++ b/GDAXSharp/Services/Orders/Models/Order.cs
@@ -17,12 +17,12 @@ namespace GDAXSharp.Services.Orders.Models
 
         public decimal Price { get; set; }
 
-	    [JsonProperty("stop")]
-	    [JsonConverter(typeof(StringEnumConverter))]
-		public StopType StopType { get; set; }
+        [JsonProperty("stop")]
+        [JsonConverter(typeof(StringEnumConverter))]
+        public StopType StopType { get; set; }
 
-		[JsonProperty("stop_price")]
-	    public decimal StopPrice { get; set; }
+        [JsonProperty("stop_price")]
+        public decimal StopPrice { get; set; }
 
         [JsonProperty("type")]
         [JsonConverter(typeof(StringEnumConverter))]

--- a/GDAXSharp/Services/Orders/Models/Order.cs
+++ b/GDAXSharp/Services/Orders/Models/Order.cs
@@ -17,6 +17,13 @@ namespace GDAXSharp.Services.Orders.Models
 
         public decimal Price { get; set; }
 
+	    [JsonProperty("stop")]
+	    [JsonConverter(typeof(StringEnumConverter))]
+		public StopType StopType { get; set; }
+
+		[JsonProperty("stop_price")]
+	    public decimal StopPrice { get; set; }
+
         [JsonProperty("type")]
         [JsonConverter(typeof(StringEnumConverter))]
         public OrderType OrderType { get; set; }

--- a/GDAXSharp/Services/Orders/Models/StopLimitOrder.cs
+++ b/GDAXSharp/Services/Orders/Models/StopLimitOrder.cs
@@ -1,12 +1,12 @@
-﻿using GDAXSharp.Services.Orders.Types;
+﻿using System;
+using GDAXSharp.Services.Orders.Types;
 using GDAXSharp.Shared.Types;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
-using System;
 
 namespace GDAXSharp.Services.Orders.Models
 {
-    public class Order
+    public class StopLimitOrder
     {
         public Guid? ClientOid { get; set; }
 
@@ -16,6 +16,13 @@ namespace GDAXSharp.Services.Orders.Models
         public decimal Size { get; set; }
 
         public decimal Price { get; set; }
+
+        [JsonProperty("stop")]
+        [JsonConverter(typeof(StringEnumConverter))]
+        public StopType StopType { get; set; }
+
+        [JsonProperty("stop_price")]
+        public decimal StopPrice { get; set; }
 
         [JsonProperty("type")]
         [JsonConverter(typeof(StringEnumConverter))]
@@ -31,5 +38,7 @@ namespace GDAXSharp.Services.Orders.Models
         public GoodTillTime CancelAfter { get; set; }
 
         public bool PostOnly { get; set; }
+
+
     }
 }

--- a/GDAXSharp/Services/Orders/OrdersService.cs
+++ b/GDAXSharp/Services/Orders/OrdersService.cs
@@ -89,30 +89,30 @@ namespace GDAXSharp.Services.Orders
             return await PlaceOrderAsync(order);
         }
 
-	    public async Task<OrderResponse> PlaceStopLimitOrderAsync(
-		    OrderSide side,
-		    ProductType productId,
-		    decimal size,
-		    decimal stopPrice,
-		    decimal limitPrice,
-			bool postOnly = true,
-		    Guid? clientOid = null)
-	    {
-		    var order = new Order
-		    {
-				Side = side,
-				ProductId = productId,
-				OrderType = OrderType.Limit,
-				Price = limitPrice,
-			    Size = size,
-				StopType = side == OrderSide.Buy ? StopType.Entry : StopType.Loss,
-				StopPrice = stopPrice,
-				ClientOid = clientOid,
-			    PostOnly = postOnly,
-			};
+        public async Task<OrderResponse> PlaceStopLimitOrderAsync(
+            OrderSide side,
+            ProductType productId,
+            decimal size,
+            decimal stopPrice,
+            decimal limitPrice,
+            bool postOnly = true,
+            Guid? clientOid = null)
+        {
+            var order = new Order
+            {
+                Side = side,
+                ProductId = productId,
+                OrderType = OrderType.Limit,
+                Price = limitPrice,
+                Size = size,
+                StopType = side == OrderSide.Buy ? StopType.Entry : StopType.Loss,
+                StopPrice = stopPrice,
+                ClientOid = clientOid,
+                PostOnly = postOnly,
+            };
 
-		    return await PlaceOrderAsync(order);
-		}
+            return await PlaceOrderAsync(order);
+        }
 
         public async Task<OrderResponse> PlaceStopOrderAsync(
             OrderSide side,

--- a/GDAXSharp/Services/Orders/OrdersService.cs
+++ b/GDAXSharp/Services/Orders/OrdersService.cs
@@ -105,7 +105,9 @@ namespace GDAXSharp.Services.Orders
                 OrderType = OrderType.Limit,
                 Price = limitPrice,
                 Size = size,
-                StopType = side == OrderSide.Buy ? StopType.Entry : StopType.Loss,
+                StopType = side == OrderSide.Buy 
+                    ? StopType.Entry
+                    : StopType.Loss,
                 StopPrice = stopPrice,
                 ClientOid = clientOid,
                 PostOnly = postOnly,

--- a/GDAXSharp/Services/Orders/OrdersService.cs
+++ b/GDAXSharp/Services/Orders/OrdersService.cs
@@ -98,7 +98,7 @@ namespace GDAXSharp.Services.Orders
             bool postOnly = true,
             Guid? clientOid = null)
         {
-            var order = new Order
+            var order = new StopLimitOrder
             {
                 Side = side,
                 ProductId = productId,
@@ -136,7 +136,7 @@ namespace GDAXSharp.Services.Orders
             return await PlaceOrderAsync(order);
         }
 
-        private async Task<OrderResponse> PlaceOrderAsync(Order order)
+        private async Task<OrderResponse> PlaceOrderAsync(object order)
         {
             return await SendServiceCall<OrderResponse>(HttpMethod.Post, "/orders", JsonConfig.SerializeObject(order)).ConfigureAwait(false);
         }

--- a/GDAXSharp/Services/Orders/OrdersService.cs
+++ b/GDAXSharp/Services/Orders/OrdersService.cs
@@ -89,6 +89,31 @@ namespace GDAXSharp.Services.Orders
             return await PlaceOrderAsync(order);
         }
 
+	    public async Task<OrderResponse> PlaceStopLimitOrderAsync(
+		    OrderSide side,
+		    ProductType productId,
+		    decimal size,
+		    decimal stopPrice,
+		    decimal limitPrice,
+			bool postOnly = true,
+		    Guid? clientOid = null)
+	    {
+		    var order = new Order
+		    {
+				Side = side,
+				ProductId = productId,
+				OrderType = OrderType.Limit,
+				Price = limitPrice,
+			    Size = size,
+				StopType = side == OrderSide.Buy ? StopType.Entry : StopType.Loss,
+				StopPrice = stopPrice,
+				ClientOid = clientOid,
+			    PostOnly = postOnly,
+			};
+
+		    return await PlaceOrderAsync(order);
+		}
+
         public async Task<OrderResponse> PlaceStopOrderAsync(
             OrderSide side,
             ProductType productId,

--- a/GDAXSharp/Services/Orders/Types/StopType.cs
+++ b/GDAXSharp/Services/Orders/Types/StopType.cs
@@ -2,11 +2,11 @@
 
 namespace GDAXSharp.Services.Orders.Types
 {
-	public enum StopType
-	{
-		[EnumMember(Value = "loss")]
-		Loss,
-		[EnumMember(Value = "entry")]
-		Entry
-	}
+    public enum StopType
+    {
+        [EnumMember(Value = "loss")]
+        Loss,
+        [EnumMember(Value = "entry")]
+        Entry
+    }
 }

--- a/GDAXSharp/Services/Orders/Types/StopType.cs
+++ b/GDAXSharp/Services/Orders/Types/StopType.cs
@@ -1,0 +1,12 @@
+﻿using System.Runtime.Serialization;
+
+namespace GDAXSharp.Services.Orders.Types
+{
+	public enum StopType
+	{
+		[EnumMember(Value = "loss")]
+		Loss,
+		[EnumMember(Value = "entry")]
+		Entry
+	}
+}

--- a/README.md
+++ b/README.md
@@ -212,6 +212,7 @@ Thanks for contributing!
 - @chrisw000
 - @confessore
 - @sotam
+- @bravesirandrew
 
 <h1>Bugs or questions?</h1>
 


### PR DESCRIPTION
Shall we try this again? This version should fix issue #121 while still allowing for stop limit orders to be placed. I also added tests on the OrderService for the send side of the IHttpClient, which would have caught the previous bug. I have tested both market, stop, and stop limit orders against the live GDAX servers. All seem to be working fine.